### PR TITLE
Bug fixes for init messages

### DIFF
--- a/c_src/gen_driver.c
+++ b/c_src/gen_driver.c
@@ -93,7 +93,9 @@ async(void *data) {
   }
 
   /* Dispatch unless an error or initialization occurred */
-  if (!strlen(ptr->res->error) && ptr->req->cmd != GD_CMD_INIT)
+  if (ptr->req->cmd == GD_CMD_INIT) {
+    ei_decode_list_header(ptr->req->buf, &ptr->req->index, NULL);
+  } else if (!strlen(ptr->res->error))
     dispatch(ptr->req, ptr->res, ptr->drv_state, trd_state);
 }
 
@@ -178,7 +180,6 @@ ready(ErlDrvData drv_data, ErlDrvThreadData thread_data) {
   gd_ptr_t *ptr = (void *)thread_data;
 
   /* Check, if we reached the end of the request buffer */
-  ei_decode_list_header(ptr->req->buf, &ptr->req->index, NULL);
   if (!error_occurred(ptr->res) && ptr->req->len != ptr->req->index)
     error_set(ptr->res, GD_ERR_DECODE);
 

--- a/src/gen_driver.erl
+++ b/src/gen_driver.erl
@@ -49,7 +49,10 @@
 % we initialize all async threads.
 init(State = #state{ name = Name }) ->
   NewState = State#state{ port = open_port({ spawn, Name }, [binary]) },
-  [ port_control(NewState#state.port, (1 bsl 30) - 1, term_to_binary([])) ||
+  [ begin
+      port_control(NewState#state.port, (1 bsl 30) - 1, term_to_binary([])),
+      ok = wait_result(NewState#state.port)
+    end ||
     _ <- lists:seq(1, erlang:system_info(thread_pool_size)) ],
   { ok, NewState }.
 


### PR DESCRIPTION
These are 2 fixes related to the handling of the initialization messages:

1. The current code does not wait for the result of the init messages (`(1 bsl 30) - 1`), so if you send a command right after starting the gen_driver, then reading the result from that command sometimes receives the `ok` from the init
2. The `ready` function tries to read a list header after the request is processed, this is also unspecified behaviour, as only the init message leaves an empty list in the request