### PR TITLE
Balance ports between threads by default when returning the given key

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,9 @@ thread_destroy(void *trd_state) { }
 
 /**
  * Load balancing among threads. Balancing is implemented as a modulo
- * operation: % THREADS. Return null for round-robin strategy.
+ * operation: % THREADS. Return NULL for round-robin strategy. Return the key
+ * parameter unchanged to ensure that the same port will always run on the same
+ * thread.
  */
 unsigned int *
 balance(int cmd, unsigned char syn, unsigned int *key) {

--- a/c_src/gen_driver.c
+++ b/c_src/gen_driver.c
@@ -270,7 +270,7 @@ control(
     ptr->req = req; ptr->res = res;
 
     /* Pass the request to a worker thread */
-    unsigned int key = 0;
+    unsigned int key = driver_async_port_key(((gd_t *)drv_data)->port);
     driver_async(((gd_t *)drv_data)->port,
       balance(req->cmd, req->syn, &key), async, ptr, NULL);
     encode_ok(*rbuf, &index);


### PR DESCRIPTION
The balance key is set to 0 by default which means that all ports would run on the one same thread.

Instead of this, we could link each port to a different thread as a default option which is useful if, for example you want the code to run on exactly 5 threads with 5 ports.